### PR TITLE
Peg coffee-script at 1.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "author": "Vojta Jina <vojta.jina@gmail.com>",
   "dependencies": {
-    "coffee-script": "~1",
+    "coffee-script": "1.9.0",
     "object-assign": "^4.1.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
This ensures our tests, which are susceptible to the Coffeescript bug [here](https://github.com/jashkenas/coffeescript/issues/3891#issuecomment-255233415) are compiled correctly.